### PR TITLE
Increase default builtevents watch timeout

### DIFF
--- a/src/jobs/watch.yml
+++ b/src/jobs/watch.yml
@@ -7,4 +7,5 @@ executor: ruby
 resource_class: small
 
 steps:
-  - buildevents/watch_build_and_finish
+  - buildevents/watch_build_and_finish:
+      timeout: 45


### PR DESCRIPTION
We aim for less than 15 minutes builds/deploys, but some runs may take a
bit longer.

This prevents "failed" workflows from showing up in Honeycomb when they
actually succeed and gives us a better visibility of how slow some
builds are.