### PR TITLE
Bump ruby to 3.1 [semver:minor]

### DIFF
--- a/src/executors/ruby.yml
+++ b/src/executors/ruby.yml
@@ -7,7 +7,7 @@ parameters:
 
       https://hub.docker.com/r/carwow/ruby-ci/tags?page=1&ordering=last_updated
     type: string
-    default: "2.7"
+    default: "3.1"
 
 docker:
   - image: carwow/ruby-ci:<< parameters.tag >>


### PR DESCRIPTION
I'm [updating the carwow-google-ads gem](https://github.com/carwow/carwow_google_ads/pull/84) to require Rails 7, and it makes sense (at least to me) to also require Ruby 3.1 as the major services that would use that are all upgraded to >= 3.1.0.

However, I can't do this with the current 0.4 version of this orb, as it grabs Ruby 2.7

This updates it and would be a new minor version (or maybe we want a major version as it's 2 -> 3)