### PR TITLE
Add command: heroku_release_succeeded

### DIFF
--- a/src/commands/add_workflow_attempt.yml
+++ b/src/commands/add_workflow_attempt.yml
@@ -2,6 +2,7 @@ description: Add workflow run attempt count to Honeycomb
 
 steps:
   - run:
+      name: fetching workflow_attempt
       command: |
         PIPELINE_ID=$(curl -s -H 'Accept: application/json' -H "Circle-Token: $CIRCLE_TOKEN" "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID" | jq '.pipeline_id' | tr -d '"')
         WORKFLOW_COUNT=$(curl -s -H 'Accept: application/json' -H "Circle-Token: $CIRCLE_TOKEN" "https://circleci.com/api/v2/pipeline/$PIPELINE_ID/workflow" | jq '.items | length')

--- a/src/commands/heroku_release_succeeded.yml
+++ b/src/commands/heroku_release_succeeded.yml
@@ -1,0 +1,44 @@
+description: Verify the latest Heroku release succeeded
+
+parameters:
+  app:
+    description: Heroku's application name
+    type: string
+
+steps:
+  - run:
+      name: heroku release succeeded
+      command: |
+        app="<<parameters.app>>"
+        retries=30 # This waits for 5 minutes for the release to be successful given the 10 seconds sleep below.
+
+        while [ $retries -gt 0 ] && heroku releases:info --app "$app" --json | grep status | grep -q pending; do
+          echo "Release is pending..."
+          ((retries--))
+          sleep 10
+        done
+
+        status=$(heroku releases:info --app "$app" --json | jq --raw-output .status)
+        case $status in
+        succeeded)
+          echo "Release succeeded!"
+          exit 0
+          ;;
+        failed)
+          echo "Release failed!"
+          echo "Retry build or get help."
+          exit 1
+          ;;
+        pending)
+          echo "Release is still pending!"
+          echo "Heroku may have an ongoing incident."
+          echo "Check Heroku releases manually or get help."
+          exit 2
+          ;;
+        *)
+          echo "Release status is unexpected: $status"
+          echo "Heroku may have an ongoing incident."
+          echo "Check Heroku releases manually or get help."
+          exit 3
+          ;;
+        esac


### PR DESCRIPTION
Extracted from: https://github.com/carwow/docker-ruby-ci/blob/main/image/scripts/release_succeeded

We want to use this for carwow-airflow which doesn't use docker-ruby-ci image.

In the future, we may completely move all CI pipelines to use the orb
commands and jobs only instead of the docker image scripts.