### PR TITLE
Add cache_key to add_deploy_duration_ms command and start job

### DIFF
--- a/src/commands/add_deploy_duration_ms.yml
+++ b/src/commands/add_deploy_duration_ms.yml
@@ -1,8 +1,17 @@
 description: Add duration since first workflow for this commit to Honeycomb
 
+parameters:
+  cache_key:
+    description: >
+      The cache key which includes the build start timestamp file.
+
+      See `start` job.
+    type: string
+    default: 'build-start-{{ .Environment.CIRCLE_SHA1 }}'
+
 steps:
   - restore_cache:
-      key: 'build-start-{{ .Environment.CIRCLE_SHA1 }}'
+      key: << parameters.cache_key >>
   - buildevents/add_context:
       field_name: deploy_duration_ms
       field_value: $(expr \( $(date +%s) - $(cat /tmp/be/build_start) \) \* 1000)

--- a/src/jobs/start.yml
+++ b/src/jobs/start.yml
@@ -3,11 +3,20 @@ description: >
 
   Sets up Honeycomb buildevents and build start time.
 
+parameters:
+  cache_key:
+    description: >
+      The cache key which includes the build start timestamp file.
+
+      See `add_deploy_duration_ms` command.
+    type: string
+    default: 'build-start-{{ .Environment.CIRCLE_SHA1 }}'
+
 executor: ruby
 resource_class: small
 
 steps:
   - buildevents/start_trace
   - save_cache:
-      key: 'build-start-{{ .Environment.CIRCLE_SHA1 }}'
+      key: << parameters.cache_key >>
       paths: [/tmp/be/build_start]


### PR DESCRIPTION
So we can change the cache key for projects that deploy on a schedule
(e.g. carwow-airflow), otherwise it re-uses the timestamp from an older run.

These projects will most likely use the pipeline ID as the key.